### PR TITLE
Add go.mod to respository

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ Build with the following docker command `docker build -t binee .`
 docker run -it -v $PWD:/bineedev/go/src/github.com/carbonblack/binee binee bash
 ```
 
-Download Golang dependencies and build Binee
+Download Golang dependencies and build Binee 
 
 ```
-root@2b0fee41629f:~/go/src/github.com/carbonblack/binee# go get
 root@2b0fee41629f:~/go/src/github.com/carbonblack/binee# go build
 ```
+_Note: presence of go.mod file will direct the build utility to collect dependencies upon build, and also allow for the repository to be cloned and developed at any path (regardless of `$GOPATH`) directory_
+
 
 At this point you should be able to execute binee within the Docker container
 and see the usage menu.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/carbonblack/binee
+
+go 1.13
+
+require (
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/kgwinnup/gapstone v0.0.0-20190307034051-9f3ea2fb077c
+	github.com/unicorn-engine/unicorn v0.0.0-20191025210239-3b17db0d84a2
+	gopkg.in/yaml.v2 v2.2.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/kgwinnup/gapstone v0.0.0-20190307034051-9f3ea2fb077c h1:nTRM+zLMZTTWfQd/lTL7RJGJYjI+s4O0x5lsHtdaUXs=
+github.com/kgwinnup/gapstone v0.0.0-20190307034051-9f3ea2fb077c/go.mod h1:9NN44osf4zQS55nuQvbchUaE5D1WX03Cf9PzU2/XOl4=
+github.com/unicorn-engine/unicorn v0.0.0-20191025210239-3b17db0d84a2 h1:zKa6xZVMPu9+l1pRM38PA1cijzy77qYyvq23c1Qcn+4=
+github.com/unicorn-engine/unicorn v0.0.0-20191025210239-3b17db0d84a2/go.mod h1:vm0xtY46O4X0t1J6Ob+syPhvL38XAAidXGXmTSlcMZM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
+gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Addition of golang's mod feature to repository allows for:
- dependency version pinning
- automatic dependency gathering and resolution upon build
- ability to develop Binee without placing the repository in a specific directory within `$GOPATH`

Included with go.mod, go.sum changes are changes to README to reflect new build steps.