### PR TITLE
Cleaner error checking

### DIFF
--- a/pefile/pefile.go
+++ b/pefile/pefile.go
@@ -3,7 +3,6 @@ package pefile
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -214,7 +213,7 @@ func (self *PeFile) EntryPoint() uint32 {
 func LoadPeFile(path string) (*PeFile, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error opening %s file: %v", path, err))
+		return nil, fmt.Errorf("Error opening %s file: %v", path, err)
 	}
 
 	// create PeFile struct
@@ -223,14 +222,14 @@ func LoadPeFile(path string) (*PeFile, error) {
 	// get size of file, then seek back to start to reset the cursor
 	size, err := file.Seek(0, 2)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error getting size of file %s: %v", path, err))
+		return nil, fmt.Errorf("Error getting size of file %s: %v", path, err)
 	}
 	file.Seek(0, 0)
 
 	// read the file into data buffer
 	data := make([]byte, size)
 	if _, err = file.Read(data); err != nil {
-		return nil, errors.New(fmt.Sprintf("Error copying file %s into buffer: %v", path, err))
+		return nil, fmt.Errorf("Error copying file %s into buffer: %v", path, err)
 	}
 	pe.Size = size
 
@@ -240,29 +239,29 @@ func LoadPeFile(path string) (*PeFile, error) {
 	// read in DosHeader
 	pe.DosHeader = &DosHeader{}
 	if err = binary.Read(r, binary.LittleEndian, pe.DosHeader); err != nil {
-		return nil, errors.New(fmt.Sprintf("Error reading dosHeader from file %s: %v", path, err))
+		return nil, fmt.Errorf("Error reading dosHeader from file %s: %v", path, err)
 	}
 
 	// move offset to CoffHeader
 	if _, err = r.Seek(int64(pe.DosHeader.AddressExeHeader)+4, io.SeekStart); err != nil {
-		return nil, errors.New(fmt.Sprintf("Error seeking to coffHeader in file %s: %v", path, err))
+		return nil, fmt.Errorf("Error seeking to coffHeader in file %s: %v", path, err)
 	}
 
 	// read CoffHeader into struct
 	pe.CoffHeader = &CoffHeader{}
 	if err = binary.Read(r, binary.LittleEndian, pe.CoffHeader); err != nil {
-		return nil, errors.New(fmt.Sprintf("Error reading coffHeader in file %s: %v", path, err))
+		return nil, fmt.Errorf("Error reading coffHeader in file %s: %v", path, err)
 	}
 
 	// advance reader to start of OptionalHeader(32|32+)
 	if _, err = r.Seek(int64(pe.DosHeader.AddressExeHeader)+4+int64(binary.Size(CoffHeader{})), io.SeekStart); err != nil {
-		return nil, errors.New(fmt.Sprintf("Error seeking to optionalHeader in file %s: %v", path, err))
+		return nil, fmt.Errorf("Error seeking to optionalHeader in file %s: %v", path, err)
 	}
 
 	// check if pe or pe+, read 2 bytes to get Magic then seek backward two bytes
 	var _magic uint16
 	if err := binary.Read(r, binary.LittleEndian, &_magic); err != nil {
-		return nil, errors.New(fmt.Sprintf("Error reading in magic"))
+		return nil, fmt.Errorf("Error reading in magic")
 	} else {
 		if _magic == 0x10b {
 			pe.PeType = Pe32
@@ -271,7 +270,7 @@ func LoadPeFile(path string) (*PeFile, error) {
 		}
 
 		if _, err = r.Seek(int64(pe.DosHeader.AddressExeHeader)+4+int64(binary.Size(CoffHeader{})), io.SeekStart); err != nil {
-			return nil, errors.New(fmt.Sprintf("Error seeking to optionalHeader in file %s: %v", path, err))
+			return nil, fmt.Errorf("Error seeking to optionalHeader in file %s: %v", path, err)
 		}
 
 	}
@@ -280,12 +279,12 @@ func LoadPeFile(path string) (*PeFile, error) {
 	if pe.PeType == Pe32 {
 		pe.OptionalHeader = &OptionalHeader32{}
 		if err = binary.Read(r, binary.LittleEndian, pe.OptionalHeader); err != nil {
-			return nil, errors.New(fmt.Sprintf("Error reading optionalHeader32 in file %s: %v", path, err))
+			return nil, fmt.Errorf("Error reading optionalHeader32 in file %s: %v", path, err)
 		}
 	} else {
 		pe.OptionalHeader = &OptionalHeader32P{}
 		if err = binary.Read(r, binary.LittleEndian, pe.OptionalHeader); err != nil {
-			return nil, errors.New(fmt.Sprintf("Error reading optionalHeader32p in file %s: %v", path, err))
+			return nil, fmt.Errorf("Error reading optionalHeader32p in file %s: %v", path, err)
 		}
 	}
 
@@ -306,12 +305,12 @@ func LoadPeFile(path string) (*PeFile, error) {
 	// loop over each section and populate struct
 	for i := 0; i < int(pe.CoffHeader.NumberOfSections); i++ {
 		if _, err = r.Seek(sections_start+int64(binary.Size(SectionHeader{})*i), io.SeekStart); err != nil {
-			return nil, errors.New(fmt.Sprintf("Error seeking over sections in file %s: %v", path, err))
+			return nil, fmt.Errorf("Error seeking over sections in file %s: %v", path, err)
 		}
 
 		temp := SectionHeader{}
 		if err = binary.Read(r, binary.LittleEndian, &temp); err != nil {
-			return nil, errors.New(fmt.Sprintf("Error reading section[%d] in file %s: %v", i, path, err))
+			return nil, fmt.Errorf("Error reading section[%d] in file %s: %v", i, path, err)
 		}
 		pe.sectionHeaders[i] = &temp
 
@@ -328,7 +327,7 @@ func LoadPeFile(path string) (*PeFile, error) {
 		pe.Sections[i].Characteristics = temp.Characteristics
 
 		if _, err = r.Seek(int64(temp.Offset), io.SeekStart); err != nil {
-			return nil, errors.New(fmt.Sprintf("Error seeking offset in section[%s] of file %s: %v", pe.Sections[i].Name, path, err))
+			return nil, fmt.Errorf("Error seeking offset in section[%s] of file %s: %v", pe.Sections[i].Name, path, err)
 		}
 		raw := make([]byte, temp.Size)
 		if _, err = r.Read(raw); err != nil {
@@ -336,7 +335,7 @@ func LoadPeFile(path string) (*PeFile, error) {
 				pe.Sections[i].Raw = nil
 				continue
 			}
-			return nil, errors.New(fmt.Sprintf("Error reading bytes at offset[0x%x] in section[%s] of file %s: %v", pe.Sections[i].Offset, pe.Sections[i].Name, path, err))
+			return nil, fmt.Errorf("Error reading bytes at offset[0x%x] in section[%s] of file %s: %v", pe.Sections[i].Offset, pe.Sections[i].Name, path, err)
 		}
 		pe.Sections[i].Raw = raw
 	}
@@ -416,12 +415,12 @@ func (self *PeFile) readExports() error {
 
 	// seek to table offset
 	if _, err := r.Seek(int64(tableOffset), io.SeekStart); err != nil {
-		return errors.New(fmt.Sprintf("Error seeking to %s exportDirectory", self.Path))
+		return fmt.Errorf("Error seeking to %s exportDirectory", self.Path)
 	}
 
 	exportDirectory := ExportDirectory{}
 	if err := binary.Read(r, binary.LittleEndian, &exportDirectory); err != nil {
-		return errors.New(fmt.Sprintf("Error retrieving %s exportDirectory", self.Path))
+		return fmt.Errorf("Error retrieving %s exportDirectory", self.Path)
 	}
 
 	names := exportDirectory.NamesRva - section.VirtualAddress
@@ -434,12 +433,12 @@ func (self *PeFile) readExports() error {
 	for i := 0; i < int(exportDirectory.NumberOfNamePointers); i++ {
 		// seek to names table
 		if _, err := r.Seek(int64(names+uint32(i*4)), io.SeekStart); err != nil {
-			return errors.New(fmt.Sprintf("Error seeking %s for exports names table: %v", self.Path, err))
+			return fmt.Errorf("Error seeking %s for exports names table: %v", self.Path, err)
 		}
 
 		exportAddressTable := ExportAddressTable{}
 		if err := binary.Read(r, binary.LittleEndian, &exportAddressTable); err != nil {
-			return errors.New(fmt.Sprintf("Error retrieving %s exports address table: %v", self.Path, err))
+			return fmt.Errorf("Error retrieving %s exports address table: %v", self.Path, err)
 		}
 
 		name := readString(section.Raw[exportAddressTable.ExportRva-section.VirtualAddress:])
@@ -449,13 +448,13 @@ func (self *PeFile) readExports() error {
 
 		// seek to ordinals table
 		if _, err := r.Seek(int64(uint32(ordinal)*4+exportDirectory.FunctionsRva-section.VirtualAddress), io.SeekStart); err != nil {
-			return errors.New(fmt.Sprintf("Error seeking %s ordinals table: %v", self.Path, err))
+			return fmt.Errorf("Error seeking %s ordinals table: %v", self.Path, err)
 		}
 
 		// get ordinal address table
 		exportOrdinalTable := ExportAddressTable{}
 		if err := binary.Read(r, binary.LittleEndian, &exportOrdinalTable); err != nil {
-			return errors.New(fmt.Sprintf("Error retrieving %s ordinals table: %v", self.Path, err))
+			return fmt.Errorf("Error retrieving %s ordinals table: %v", self.Path, err)
 		}
 
 		rva := exportOrdinalTable.ExportRva
@@ -500,7 +499,7 @@ func (self *PeFile) SetImportAddress(importInfo *ImportInfo, realAddr uint64) er
 
 	// return error if not found
 	if sectionFound == false {
-		return errors.New(fmt.Sprintf("Error setting address for %s.%s to %x, section not found.", importInfo.DllName, importInfo.FuncName, importInfo.Offset))
+		return fmt.Errorf("Error setting address for %s.%s to %x, section not found.", importInfo.DllName, importInfo.FuncName, importInfo.Offset)
 	}
 
 	//fmt.Println(importInfo)
@@ -892,7 +891,7 @@ func (self *PeFile) updateRelocations() error {
 
 	section := self.section(5)
 	if section == nil {
-		return errors.New(fmt.Sprintf("Section not found, index 5."))
+		return fmt.Errorf("section not found, index 5")
 	}
 	// create raw data reader
 	r := bytes.NewReader(section.Raw)

--- a/util/unicorn.go
+++ b/util/unicorn.go
@@ -2,13 +2,16 @@
 // emulator that are independent from any of the process emulation happening
 package util
 
-import "strings"
-import "fmt"
-import "encoding/binary"
-import "bytes"
-import "errors"
-import "github.com/carbonblack/binee/pefile"
-import uc "github.com/unicorn-engine/unicorn/bindings/go/unicorn"
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/carbonblack/binee/pefile"
+
+	uc "github.com/unicorn-engine/unicorn/bindings/go/unicorn"
+)
 
 // StructWrite, given a struct and a unicorn memory address. Convert the struct to a byte
 // array and write that byte array to the address in the unicorn memory
@@ -209,18 +212,18 @@ func ReadPeFile(u uc.Unicorn, addr uint64) (pefile.PeFile, error) {
 	// read DosHeader
 	pe.DosHeader = &pefile.DosHeader{}
 	if buf, err = u.MemRead(addr, uint64(binary.Size(pe.DosHeader))); err != nil {
-		return pe, errors.New(fmt.Sprintf("error reading DosHeader from unicorn memory"))
+		return pe, fmt.Errorf("error reading DosHeader from unicorn memory")
 	}
 	if err = binary.Read(bytes.NewReader(buf), binary.LittleEndian, pe.DosHeader); err != nil {
-		return pe, errors.New(fmt.Sprintf("error writing DosHeader bytes to structure"))
+		return pe, fmt.Errorf("error writing DosHeader bytes to structure")
 	}
 
 	pe.CoffHeader = &pefile.CoffHeader{}
 	if buf, err = u.MemRead(uint64(pe.DosHeader.AddressExeHeader)+4, uint64(binary.Size(pe.CoffHeader))); err != nil {
-		return pe, errors.New(fmt.Sprintf("error reading CoffHeader from unicorn memory"))
+		return pe, fmt.Errorf("error reading CoffHeader from unicorn memory")
 	}
 	if err = binary.Read(bytes.NewReader(buf), binary.LittleEndian, pe.CoffHeader); err != nil {
-		return pe, errors.New(fmt.Sprintf("error writing CoffHeader bytes to structure"))
+		return pe, fmt.Errorf("error writing CoffHeader bytes to structure")
 	}
 
 	optionalHeaderAddr := addr + uint64(pe.DosHeader.AddressExeHeader) + 4 + uint64(binary.Size(pe.CoffHeader))
@@ -229,10 +232,10 @@ func ReadPeFile(u uc.Unicorn, addr uint64) (pefile.PeFile, error) {
 		pe.PeType = pefile.Pe32
 		pe.OptionalHeader = &pefile.OptionalHeader32{}
 		if buf, err = u.MemRead(optionalHeaderAddr, uint64(binary.Size(pe.OptionalHeader))); err != nil {
-			return pe, errors.New(fmt.Sprintf("error reading OptionalHeader32 from unicorn memory"))
+			return pe, fmt.Errorf("error reading OptionalHeader32 from unicorn memory")
 		}
 		if err = binary.Read(bytes.NewReader(buf), binary.LittleEndian, pe.OptionalHeader); err != nil {
-			return pe, errors.New(fmt.Sprintf("error writing OptionalHeader32 bytes to structure"))
+			return pe, fmt.Errorf("error writing OptionalHeader32 bytes to structure")
 		}
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -1,11 +1,12 @@
 package util
 
-import "os"
-import "fmt"
-import "errors"
-import "strings"
-import "math/rand"
-import "regexp"
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"regexp"
+	"strings"
+)
 
 // SearchFile is the primary function for searching the host/mock system for
 // files for use in the emulator
@@ -19,7 +20,7 @@ func SearchFile(searchPaths []string, filename string) (string, error) {
 		}
 	}
 
-	return "", errors.New(fmt.Sprintf("file '%s' not found", filename))
+	return "", fmt.Errorf("file '%s' not found", filename)
 }
 
 // NewGdtEntry initializes a gdt table entry


### PR DESCRIPTION
removed the use of the errors packaged, opted for `fmt.Errorf(...)` in place of `errors.New(fmt.Sprintf(...))`