### PR TITLE
windows: print instruction at function entry point if not fully hooked

### DIFF
--- a/windows/hooks.go
+++ b/windows/hooks.go
@@ -331,6 +331,10 @@ func (self *Instruction) String() string {
 			}
 		}
 		ret += fmt.Sprintf(") = 0x%x", self.Hook.Return)
+		if self.Hook.HookStatus != "F" {
+			// print instruction at function entry point if not fully hooked.
+			ret += fmt.Sprintf("\n[%d] %s: %s", self.ThreadId, self.Address(), self.Disassemble())
+		}
 		return ret
 	}
 }


### PR DESCRIPTION
Debug output of `binee -v` before this commit:
```
[1] 0x2000a8ad: P user32.dll:wsprintfA(lpstr = 0xb7fefbb8, lpcstr = 'Reload-%s') = 0xb7fefbb8
[1] 0x2000a8af: push ebp
[1] 0x2000a8b0: mov ebp, esp
[1] 0x2000a8b2: lea eax, [ebp + 0x10]
```

Debug output of `binee -v` after this commit:
```
[1] 0x20f168ad: P wsprintfA(lpstr = 0xb7fefbb8, lpcstr = 'Reload-%s') = 0xb7fefbb8
[1] 0x20f168ad: mov edi, edi
[1] 0x20f168af: push ebp
[1] 0x20f168b0: mov ebp, esp
[1] 0x20f168b2: lea eax, [ebp + 0x10]
```

Notice the `mov edi, edi` at the function entry point.

---

Disassembly ref from IDA:

```asm
.text:7E41A8AD ; int wsprintfA(LPSTR, LPCSTR, ...)
.text:7E41A8AD                 public _wsprintfA
.text:7E41A8AD _wsprintfA      proc near               ; DATA XREF: .text:off_7E413928↑o
.text:7E41A8AD
.text:7E41A8AD arg_0           = dword ptr  8
.text:7E41A8AD arg_4           = dword ptr  0Ch
.text:7E41A8AD arglist         = byte ptr  10h
.text:7E41A8AD
.text:7E41A8AD                 mov     edi, edi
.text:7E41A8AF                 push    ebp
.text:7E41A8B0                 mov     ebp, esp
.text:7E41A8B2                 lea     eax, [ebp+arglist]
```

Fixes #37.