### PR TITLE
replaced command line parser fucntion with flag package

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,125 +2,57 @@
 // parameterized options passed in via command line
 package main
 
-import "fmt"
-import "log"
-import "os"
-import "github.com/carbonblack/binee/pefile"
-import "github.com/carbonblack/binee/windows"
-import "github.com/carbonblack/binee/util"
-import uc "github.com/unicorn-engine/unicorn/bindings/go/unicorn"
+import (
+	"flag"
+	"fmt"
+	"log"
 
-type Options struct {
-	Binary       string
-	Args         []string
-	Verbose      int
-	ApisetLookup string
-	ApisetDump   bool
-	Usage        bool
-	Exports      bool
-	Imports      bool
-	ImportsFuncs bool
-	SingleStep   bool
-	Config       string
-	OutputJson   bool
-	ShowDll      bool
-	CallDllMain  bool
-}
+	"github.com/carbonblack/binee/pefile"
+	"github.com/carbonblack/binee/util"
+	"github.com/carbonblack/binee/windows"
 
-// parseArgs parses out command line arguments passed into binee on start
-func parseArgs(args []string) Options {
-	options := Options{}
-	options.Args = make([]string, 0)
-	options.ApisetDump = false
-	options.CallDllMain = false
-
-	for i := 0; i < len(args); i++ {
-
-		if args[i][0] == '-' {
-			switch args[i][1] {
-			case 'v':
-				options.Verbose += 1
-				if len(args[i]) > 2 && args[i][2] == 'v' {
-					options.Verbose += 1
-				}
-			case 'a':
-				if len(args[i]) == 2 {
-					options.ApisetLookup = args[i+1]
-					i += 1
-				} else {
-					options.ApisetLookup = args[i][2:]
-				}
-			case 'A':
-				options.ApisetDump = true
-			case 'c':
-				if len(args[i]) == 2 {
-					options.Config = args[i+1]
-					i += 1
-				} else {
-					options.Config = args[i][2:]
-				}
-			case 'd':
-				options.ShowDll = true
-			case 'e':
-				options.Exports = true
-			case 'h':
-				options.Usage = true
-			case 'i':
-				options.Imports = true
-				if len(args[i]) > 2 && args[i][2] == 'i' {
-					options.ImportsFuncs = true
-				}
-			case 'j':
-				options.Verbose = -1
-				options.OutputJson = true
-			case 'l':
-				options.CallDllMain = true
-			case 's':
-				options.SingleStep = true
-			}
-		} else {
-			if len(options.Args) == 0 {
-				options.Binary = args[i]
-			}
-			options.Args = append(options.Args, args[i])
-		}
-	}
-
-	return options
-}
-
-// usage prints out the command line flags availabe to Binee
-func usage() {
-	fmt.Println("usage ./binee [-aAhvveis] [FILE] [ARGS]")
-	fmt.Println("  -a <apiset dll name>     Returns the real dll name given an apiset dll")
-	fmt.Println("  -A                       List all apisets and their mappings")
-	fmt.Println("  -c FILE                  Path to a configuration file")
-	fmt.Println("  -d                       Show dll names with function in output")
-	fmt.Println("  -e FILE                  List file exports")
-	fmt.Println("  -h                       Show this usage menu")
-	fmt.Println("  -i FILE                  List file imports")
-	fmt.Println("  -j                       Output as JSON")
-	fmt.Println("  -l                       Run full DllMain of imported functions with debug output")
-	fmt.Println("  -s                       Run application through binee debugger")
-	fmt.Println("  -v[v]                    Verbosity level, two v's for more verbose")
-}
+	uc "github.com/unicorn-engine/unicorn/bindings/go/unicorn"
+)
 
 func main() {
 
-	//parse all command line arguments and get executable to emulate
-	options := parseArgs(os.Args[1:])
+	isAPISetLookup := flag.String("a", "", "get the real dll name from an apiset name")
+	listAllAPISets := flag.Bool("A", false, "list all apisets and their mappings")
+	showDLL := flag.Bool("d", false, "show the dll prfix on all function calls")
+	configFilePath := flag.String("c", "", "path to configuration file")
+	listExports := flag.Bool("e", false, "dump pe file's exports table")
+	listImports := flag.Bool("i", false, "dump a pe file's imports table")
+	showHelp := flag.Bool("h", false, "show help menu")
+	outputJSON := flag.Bool("j", false, "output data as json")
+	verbose2 := flag.Bool("vv", false, "verbose level 2")
+	verbose1 := flag.Bool("v", false, "verbose level 1")
+	rootFolder := flag.String("r", "os/win10_32", "root path of mock file system, defaults to ./os/win10_32")
+
+	flag.Parse()
+
+	if *showHelp {
+		flag.PrintDefaults()
+		return
+	}
+
+	verboseLevel := 0
+	if *verbose1 {
+		verboseLevel = 1
+	}
+	if *verbose2 {
+		verboseLevel = 2
+	}
 
 	// if apiset dump option, load apisetschema.dll and dump all apisets
-	if options.ApisetDump {
-		rootFolder := "os/win10_32/"
-		if options.Config != "" {
-			conf, err := util.ReadGenericConfig(options.Config)
+	if *listAllAPISets {
+		if *configFilePath != "" {
+			conf, err := util.ReadGenericConfig(*configFilePath)
 			if err != nil {
 				log.Fatal(err)
 			}
-			rootFolder = conf.Root
+			rootFolder = &conf.Root
 		}
-		path, err := util.SearchFile([]string{"C:\\Windows\\System32", rootFolder + "windows/system32"}, "apisetschema.dll")
+		path, err := util.SearchFile([]string{"C:\\Windows\\System32", *rootFolder + "windows/system32"}, "apisetschema.dll")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -135,22 +67,21 @@ func main() {
 	}
 
 	// if apiset lookup, load apisetschema.dll and look up the apiset name
-	if options.ApisetLookup != "" {
-		rootFolder := "os/win10_32/"
-		if options.Config != "" {
-			conf, err := util.ReadGenericConfig(options.Config)
+	if *isAPISetLookup != "" {
+		if *configFilePath != "" {
+			conf, err := util.ReadGenericConfig(*configFilePath)
 			if err != nil {
 				log.Fatal(err)
 			}
-			rootFolder = conf.Root
+			rootFolder = &conf.Root
 		}
-		path, err := util.SearchFile([]string{"C:\\Windows\\System32", rootFolder + "windows/system32"}, "apisetschema.dll")
+		path, err := util.SearchFile([]string{"C:\\Windows\\System32", *rootFolder + "windows/system32"}, "apisetschema.dll")
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		apiset, _ := pefile.LoadPeFile(path)
-		lookup := options.ApisetLookup[0 : len(options.ApisetLookup)-6]
+		lookup := (*isAPISetLookup)[0 : len(*isAPISetLookup)-6]
 		if apiset.Apisets[lookup] != nil {
 			for i := 0; i < len(apiset.Apisets[lookup]); i++ {
 				fmt.Println("  ", apiset.Apisets[lookup][i])
@@ -163,14 +94,14 @@ func main() {
 	}
 
 	// quit if no binary is passed in
-	if options.Binary == "" {
-		usage()
+	if len(flag.Args()) == 0 {
+		flag.PrintDefaults()
 		return
 	}
 
 	// print the binaries import table
-	if options.Imports {
-		if pe, err := pefile.LoadPeFile(options.Binary); err == nil {
+	if *listImports {
+		if pe, err := pefile.LoadPeFile(flag.Args()[0]); err == nil {
 			for _, importInfo := range pe.Imports {
 				fmt.Printf("%s.%s => 0x%x\n", importInfo.DllName, importInfo.FuncName, importInfo.Offset)
 			}
@@ -179,8 +110,8 @@ func main() {
 	}
 
 	// print the binaries export table
-	if options.Exports {
-		if pe, err := pefile.LoadPeFile(options.Binary); err == nil {
+	if *listExports {
+		if pe, err := pefile.LoadPeFile(flag.Args()[0]); err == nil {
 			for _, export := range pe.Exports {
 				fmt.Println(export.Name)
 			}
@@ -189,15 +120,11 @@ func main() {
 	}
 
 	// now start the emulator with the various options
-	emu, err := windows.New(options.Binary, uc.ARCH_X86, uc.MODE_32, options.Args, options.Verbose, options.Config, options.ShowDll, options.CallDllMain)
-	emu.AsJson = options.OutputJson
+	emu, err := windows.New(flag.Args()[0], uc.ARCH_X86, uc.MODE_32, flag.Args()[1:], verboseLevel, *configFilePath, *showDLL, false)
+	emu.AsJson = *outputJSON
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if options.SingleStep == false {
-		emu.Start()
-	} else {
-		emu.StartSingleStep()
-	}
+	emu.Start()
 }

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	outputJSON := flag.Bool("j", false, "output data as json")
 	verbose2 := flag.Bool("vv", false, "verbose level 2")
 	verbose1 := flag.Bool("v", false, "verbose level 1")
-	rootFolder := flag.String("r", "os/win10_32", "root path of mock file system, defaults to ./os/win10_32")
+	rootFolder := flag.String("r", "os/win10_32/", "root path of mock file system, defaults to ./os/win10_32")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	outputJSON := flag.Bool("j", false, "output data as json")
 	verbose2 := flag.Bool("vv", false, "verbose level 2")
 	verbose1 := flag.Bool("v", false, "verbose level 1")
+	runDLLMain := flag.Bool("l", false, "call DLLMain while loading DLLs")
 	rootFolder := flag.String("r", "os/win10_32/", "root path of mock file system, defaults to ./os/win10_32")
 
 	flag.Parse()
@@ -119,8 +120,15 @@ func main() {
 		return
 	}
 
+	options := windows.InitWinEmulatorOptions()
+	options.VerboseLevel = verboseLevel
+	options.ConfigPath = *configFilePath
+	options.RootFolder = *rootFolder
+	options.ShowDLL = *showDLL
+	options.RunDLLMain = *runDLLMain
+
 	// now start the emulator with the various options
-	emu, err := windows.New(flag.Args()[0], uc.ARCH_X86, uc.MODE_32, flag.Args()[1:], verboseLevel, *configFilePath, *showDLL, false)
+	emu, err := windows.New(flag.Args()[0], uc.ARCH_X86, uc.MODE_32, flag.Args()[1:], options)
 	emu.AsJson = *outputJSON
 	if err != nil {
 		log.Fatal(err)

--- a/windows/winemulator.go
+++ b/windows/winemulator.go
@@ -119,7 +119,31 @@ func (self *WinEmulator) GetHook(addr uint64) (string, string, *Hook) {
 	return "", "", nil
 }
 
-func New(path string, arch, mode int, args []string, verbose int, config string, showDll bool, calldllmain bool) (*WinEmulator, error) {
+// WinEmulatorOptions will get passed into the WinEmulator
+type WinEmulatorOptions struct {
+	RootFolder   string
+	RunDLLMain   bool
+	ConfigPath   string
+	VerboseLevel int
+	ShowDLL      bool
+}
+
+// InitWinEmulatorOptions will build a default option struct to pass into WinEmulator
+func InitWinEmulatorOptions() *WinEmulatorOptions {
+	return &WinEmulatorOptions{
+		RootFolder:   "os/win10_32/",
+		RunDLLMain:   false,
+		ConfigPath:   "",
+		VerboseLevel: 0,
+		ShowDLL:      false,
+	}
+}
+
+func New(path string, arch, mode int, args []string, options *WinEmulatorOptions) (*WinEmulator, error) {
+	if options == nil {
+		options = InitWinEmulatorOptions()
+	}
+
 	var err error
 	emu := WinEmulator{}
 	emu.UcMode = mode
@@ -127,7 +151,7 @@ func New(path string, arch, mode int, args []string, verbose int, config string,
 	emu.Timestamp = time.Now().Unix()
 	emu.Ticks = 1
 	emu.Binary = path
-	emu.Verbosity = verbose
+	emu.Verbosity = options.VerboseLevel
 	emu.Args = args
 	emu.Argc = uint64(len(args))
 	emu.nameToHook = make(map[string]*Hook)
@@ -137,7 +161,7 @@ func New(path string, arch, mode int, args []string, verbose int, config string,
 	emu.libRealLib = make(map[string]string)
 	emu.Handles = make(map[uint64]*Handle)
 	//this is the first thread
-	emu.ShowDll = showDll
+	emu.ShowDll = options.ShowDLL
 	emu.MemRegions = &MemRegions{}
 	// define each memory section's size
 	emu.MemRegions.ProcInfoSize = uint64(4 * 1024 * 1024)
@@ -208,7 +232,7 @@ func New(path string, arch, mode int, args []string, verbose int, config string,
 	emu.Opts.SystemTime.Minute = time.Now().Minute()
 	emu.Opts.SystemTime.Second = time.Now().Second()
 	emu.Opts.SystemTime.Millisecond = 14
-	emu.Opts.Root = "os/win10_32/"
+	emu.Opts.Root = options.RootFolder
 	emu.Opts.Env = make([]Env, 20)
 	emu.Opts.Env = append(emu.Opts.Env, Env{"ALLUSERSPROFILE", "C:\\ProgramData"})
 	emu.Opts.Env = append(emu.Opts.Env, Env{"APPDATA", "C:\\Users\\" + emu.Opts.User + "\\AppData\\roaming"})
@@ -271,7 +295,7 @@ func New(path string, arch, mode int, args []string, verbose int, config string,
 	emu.Opts.TempRegistry["HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\PowerShell\\1\\PID"] = "89383-100-0001260-04309"
 
 	var buf []byte
-	if buf, err = ioutil.ReadFile(config); err == nil {
+	if buf, err = ioutil.ReadFile(options.ConfigPath); err == nil {
 		_ = yaml.Unmarshal(buf, &emu.Opts)
 	}
 
@@ -290,7 +314,7 @@ func New(path string, arch, mode int, args []string, verbose int, config string,
 	if err != nil {
 		return nil, err
 	}
-	err = emu.initPe(pe, path, arch, mode, args, calldllmain)
+	err = emu.initPe(pe, path, arch, mode, args, options.RunDLLMain)
 
 	emu.Cpu = core.NewCpuManager(emu.Uc, emu.UcMode, emu.MemRegions.StackAddress, emu.MemRegions.StackSize, emu.MemRegions.HeapAddress, emu.MemRegions.HeapSize)
 	emu.Scheduler = NewScheduleManager(&emu)


### PR DESCRIPTION
additionally, there is a -r option which will specify the root dir for the mock OS without requiring a configuration file. This is useful if you want to still use the defaults, but change the root. For example, switching between PE and PE+, same defaults, different file system.