### PR TITLE
Lowercase, DRV and hooks

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -2,21 +2,24 @@ package util
 
 import (
 	"fmt"
+	"io/ioutil"
 	"math/rand"
-	"os"
 	"regexp"
 	"strings"
 )
 
-// SearchFile is the primary function for searching the host/mock system for
-// files for use in the emulator
+//SearchFile is the primary function for searching the host/mock system for
+//files for use in the emulator
 func SearchFile(searchPaths []string, filename string) (string, error) {
 	for i := 0; i < len(searchPaths); i++ {
-		if _, err := os.Stat(searchPaths[i] + "/" + strings.ToLower(filename)); err == nil {
-			return searchPaths[i] + "/" + strings.ToLower(filename), nil
+		files, err := ioutil.ReadDir(searchPaths[i])
+		if err != nil {
+			return "", fmt.Errorf("directory '%s'not found", searchPaths[i])
 		}
-		if _, err := os.Stat(searchPaths[i] + "/" + filename); err == nil {
-			return searchPaths[i] + "/" + filename, nil
+		for _, file := range files {
+			if strings.ToLower(file.Name()) == strings.ToLower(filename) {
+				return searchPaths[i] + "/" + file.Name(), nil
+			}
 		}
 	}
 

--- a/windows/constants.go
+++ b/windows/constants.go
@@ -33,6 +33,17 @@ const (
 	STATUS_WAIT_3    = 0x3
 	STATUS_WAIT_63   = 0x3f
 	STATUS_ABANDONED = 0x80
+
+	//MEMORY
+	//https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc
+	MEM_COMMIT      = 0x00001000
+	MEM_RESERVE     = 0x00002000
+	MEM_RESET       = 0x00080000
+	MEM_RESET_UNDO  = 0x01000000
+	MEM_LARGE_PAGES = 0x20000000
+	MEM_PHYSICAL    = 0x00400000
+	MEM_TOP_DOWN    = 0x00100000
+	MEM_WRITE_WATCH = 0x00200000
 )
 
 var EN_LOCALE = map[int]string{

--- a/windows/kernel32.go
+++ b/windows/kernel32.go
@@ -120,7 +120,7 @@ func loadLibrary(emu *WinEmulator, in *Instruction, wide bool) func(emu *WinEmul
 	name = strings.Trim(name, "\x00")
 	name = strings.Trim(name, "\u0000")
 
-	if strings.Contains(name, ".dll") == false {
+	if name[len(name)-4:] != ".dll" && name[len(name)-4:] != ".drv" {
 		name += ".dll"
 	}
 

--- a/windows/kernel32.go
+++ b/windows/kernel32.go
@@ -339,7 +339,11 @@ func KernelbaseHooks(emu *WinEmulator) {
 			return SkipFunctionStdCall(true, 0x1234)(emu, in)
 		},
 	})
-	emu.AddHook("", "GetCurrentProcess", &Hook{Parameters: []string{}})
+	emu.AddHook("", "GetCurrentProcess", &Hook{Parameters: []string{},
+		Fn: func(emu *WinEmulator, in *Instruction) bool {
+			return SkipFunctionStdCall(true, 0x1234)(emu, in)
+		},
+	})
 	emu.AddHook("", "GetCurrentProcessId", &Hook{
 		Parameters: []string{},
 		Fn: func(emu *WinEmulator, in *Instruction) bool {
@@ -363,7 +367,11 @@ func KernelbaseHooks(emu *WinEmulator) {
 			return SkipFunctionStdCall(true, 0x2)(emu, in)
 		},
 	})
-	emu.AddHook("", "GetLastError", &Hook{Parameters: []string{}})
+	emu.AddHook("", "GetLastError", &Hook{Parameters: []string{},
+		Fn: func(emu *WinEmulator, in *Instruction) bool {
+			return SkipFunctionStdCall(true, 0x0)(emu, in)
+		},
+	})
 	emu.AddHook("", "GetLastActivePopup", &Hook{
 		Parameters: []string{"hWnd"},
 		Fn:         SkipFunctionStdCall(true, 0x1),
@@ -621,11 +629,11 @@ func KernelbaseHooks(emu *WinEmulator) {
 	})
 	emu.AddHook("", "GetVersionExA", &Hook{
 		Parameters: []string{"lpVersionInformation"},
-		Fn:         SkipFunctionStdCall(true, 0x12),
+		Fn:         SkipFunctionStdCall(true, 0x1),
 	})
 	emu.AddHook("", "GetVersionExW", &Hook{
 		Parameters: []string{"lpVersionInformation"},
-		Fn:         SkipFunctionStdCall(true, 0x12),
+		Fn:         SkipFunctionStdCall(true, 0x1),
 	})
 	emu.AddHook("", "GetWindowsDirectoryA", &Hook{
 		Parameters: []string{"lpBuffer", "uSize"},

--- a/windows/memoryapi.go
+++ b/windows/memoryapi.go
@@ -3,6 +3,24 @@ package windows
 func MemoryApiHooks(emu *WinEmulator) {
 	emu.AddHook("", "VirtualAlloc", &Hook{
 		Parameters: []string{"lpAddress", "dwSize", "flAllocationType", "flProtect"},
+		Fn: func(emu *WinEmulator, in *Instruction) bool {
+			lpAddress := in.Args[0] //where he wants to find some free memory
+			dwSize := in.Args[1]    //how much memory wants
+			flAllocationType := in.Args[2]
+			//tbh he should only allocate memory when he commits, but idk why binee splits MEM_COMMIT|MEM_RESERVE in 2
+			//separate calls
+			if flAllocationType == MEM_RESERVE {
+				addr := emu.Heap.Malloc(dwSize)
+				return SkipFunctionStdCall(true, addr)(emu, in)
+			} else if flAllocationType == MEM_COMMIT {
+				//return the address that he asked
+				return SkipFunctionStdCall(true, lpAddress)(emu, in)
+			} else {
+				//TODO
+				return SkipFunctionStdCall(true, 0x123)(emu, in)
+			}
+
+		},
 	})
 	emu.AddHook("", "VirtualAllocEx", &Hook{
 		Parameters: []string{"hProcess", "lpAddress", "dwSize", "flAllocationType", "flProtect"},


### PR DESCRIPTION
Did some changes: 
Since I was quite bored to have two different sets of dll (I am testing qiling too), i decided to change the Search function to retrieve even dll with camelCase names, like "KernelBase".
More, some samples use ".drv" files to load libraries, and we binee didn't check for them before, so i added that too.
Then I *tried* to implement some hooks that were only partially implemented, but to be honest, they need a revision.